### PR TITLE
fix flaky test in ConfigTest.java

### DIFF
--- a/src/test/java/com/alibaba/tamper/ConfigTest.java
+++ b/src/test/java/com/alibaba/tamper/ConfigTest.java
@@ -1,6 +1,6 @@
 package com.alibaba.tamper;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import junit.framework.Assert;
 import junit.framework.TestCase;
@@ -25,8 +25,8 @@ public class ConfigTest extends TestCase {
     public void testFileParse() {
         String file = "mapping/config.xml";
         BeanMappingConfigHelper.getInstance().registerConfig(file);
-        BeanMappingObject object = BeanMappingConfigHelper.getInstance().getBeanMappingObject(HashMap.class,
-                                                                                              HashMap.class);
+        BeanMappingObject object = BeanMappingConfigHelper.getInstance().getBeanMappingObject(LinkedHashMap.class,
+                                                                                              LinkedHashMap.class);
         assertNull(object);
         object = BeanMappingConfigHelper.getInstance().getBeanMappingObject("testConfig");
         printObject(object);


### PR DESCRIPTION
Hi! I'm a graduate student at UIUC. We are working on a project [NonDex](https://github.com/TestingResearchIllinois/NonDex) to find out flaky tests in open source projects and help developers to fix them.

The flaky test can be caused by the feature of `HashMap` or `HashSet` that when you iterate it, the order is non-deterministic. Therefore, sometimes the test passes while sometimes it fails.

We have found 2 flaky tests in your project and `com.alibaba.tamper.ConfigTest.testFileParse` is one of them.

The flakiness in this test was caused by the non-deterministic feature of `HashSet`. Therefore, I changed it to `LinkedHashSet` which is iterated in a deterministic order. And now the test is un-flaky!

Please feel free to ask me any questions about the flaky test! We are working on it. And hope this PR can be accepted!