### PR TITLE
fix flaky test in CollectionAndCollectionTest.java

### DIFF
--- a/src/test/java/com/alibaba/tamper/convertor/CollectionAndCollectionTest.java
+++ b/src/test/java/com/alibaba/tamper/convertor/CollectionAndCollectionTest.java
@@ -79,31 +79,31 @@ public class CollectionAndCollectionTest extends TestCase {
 
     @Test
     public void testArrayAndSet() {
-        Convertor intSet = helper.getConvertor(int[].class, Set.class);
-        Convertor integerSet = helper.getConvertor(Integer[].class, Set.class);
+        Convertor intSet = helper.getConvertor(int[].class, LinkedHashSet.class);
+        Convertor integerSet = helper.getConvertor(Integer[].class, LinkedHashSet.class);
 
         int[] intArray = new int[] { 1, 2 };
         Integer[] integerArray = new Integer[] { 1, 2 };
-        Set intSetValue = (Set) intSet.convert(intArray, Set.class);
-        Set integerSetValue = (Set) integerSet.convert(integerArray, Set.class);
+        Set intSetValue = (Set) intSet.convert(intArray, LinkedHashSet.class);
+        Set integerSetValue = (Set) integerSet.convert(integerArray, LinkedHashSet.class);
         assertEquals(intSetValue.size(), intArray.length);
         assertEquals(intSetValue.iterator().next(), intArray[0]);
         assertEquals(integerSetValue.size(), integerArray.length);
         assertEquals(integerSetValue.iterator().next(), integerArray[0]);
         // 测试不同类型转化, common对象
-        Set<BigInteger> intSetValueOther = (Set) intSet.convertCollection(intArray, Set.class, BigInteger.class); // int强制转为BigInteger
-        Set<BigDecimal> integerSetValueOther = (Set) integerSet.convertCollection(intArray, Set.class, BigDecimal.class); // int强制转为BigDecimal
+        Set<BigInteger> intSetValueOther = (Set) intSet.convertCollection(intArray, LinkedHashSet.class, BigInteger.class); // int强制转为BigInteger
+        Set<BigDecimal> integerSetValueOther = (Set) integerSet.convertCollection(intArray, LinkedHashSet.class, BigDecimal.class); // int强制转为BigDecimal
         assertEquals(intSetValueOther.size(), intArray.length);
         assertEquals(intSetValueOther.iterator().next().intValue(), intArray[0]);
         assertEquals(integerSetValueOther.size(), integerArray.length);
 
         // BigDecimal & BigInteger
-        Convertor bigDecimalSet = helper.getConvertor(BigDecimal[].class, HashSet.class);
+        Convertor bigDecimalSet = helper.getConvertor(BigDecimal[].class, LinkedHashSet.class);
         Convertor bigIntegerSet = helper.getConvertor(BigInteger[].class, LinkedHashSet.class);
 
         BigDecimal[] bigDecimalArray = new BigDecimal[] { BigDecimal.ZERO, BigDecimal.ONE };
         BigInteger[] bigIntegerArray = new BigInteger[] { BigInteger.ZERO, BigInteger.ONE };
-        Set bigDecimalSetValue = (Set) bigDecimalSet.convert(bigDecimalArray, HashSet.class);
+        Set bigDecimalSetValue = (Set) bigDecimalSet.convert(bigDecimalArray, LinkedHashSet.class);
         Set bigIntegerSetValue = (Set) bigIntegerSet.convert(bigIntegerArray, LinkedHashSet.class);
         assertEquals(bigDecimalSetValue.size(), bigDecimalArray.length);
         assertEquals(bigDecimalSetValue.iterator().next(), bigDecimalArray[0]);


### PR DESCRIPTION
Hi! I'm a graduate student at UIUC. We are working on a project [NonDex](https://github.com/TestingResearchIllinois/NonDex) to find out flaky tests in open source projects and help developers to fix them.

The flaky test can be caused by the feature of `HashMap` or `HashSet` that when you iterate it, the order is non-deterministic. Therefore, sometimes the test passes while sometimes it fails.

We have found 2 flaky tests in your project and `com.alibaba.tamper.convertor.CollectionAndCollectionTest` is one of them.

The flakiness in this test was caused by the non-deterministic feature of `HashSet`. Therefore, I changed it to `LinkedHashSet` which is iterated in a deterministic order. And now the test is un-flaky!

Please feel free to ask me any questions about the flaky test! We are working on it. And hope this PR can be accepted!